### PR TITLE
Blue vs. Black location pin: Deleting 2025 NYC Lat Lon

### DIFF
--- a/_data/events.json
+++ b/_data/events.json
@@ -469,7 +469,6 @@
     "description": "September 19, 2026, New York City, NY, United States"
   },
   {
-    "latitude": 40.746429,
     "organizer-url": "https://beta.nyc",
     "organizer": "BetaNYC",
     "price": "TBD",
@@ -483,7 +482,6 @@
     "country": [
       "rec45yssRULp5R735"
     ],
-    "longitude": -73.944069,
     "city": "New York City",
     "name": "CityCamp NYC",
     "venue": "CUNY School of Law",


### PR DESCRIPTION
The NYC event is showing as a black pin on the map rather than a blue pin, so i deleted the old lat Lon data to hopefully give it a blue pin. 