### PR TITLE
Harden map: skip events missing coordinates

### DIFF
--- a/_includes/map.html
+++ b/_includes/map.html
@@ -28,7 +28,11 @@
     // City locations
     {% assign events = site.data.events %}
 
-    var cities = [{% for event in events %}
+    // Only emit events that have both coordinates. A record missing
+    // latitude/longitude (e.g. a new Airtable city not yet geocoded)
+    // would otherwise render as invalid JS (`"lat": ,`) and break the
+    // entire map. Skipping it keeps every other city rendering.
+    var cities = [{% for event in events %}{% if event.latitude and event.longitude and event.latitude != "" and event.longitude != "" %}
       {
         "name": "{{ event.name }}",
         "lat": {{ event.latitude }},
@@ -37,7 +41,7 @@
         "status": "{{ event.Status }}",
         "slug": "{{ event.slug }}",
       },
-    {% endfor %}];
+    {% endif %}{% endfor %}];
 
     // Custom black map pin
     const blackPin = L.icon({


### PR DESCRIPTION
## Problem
`_includes/map.html` builds a JS `cities` array directly from `_data/events.json`. A record with a null/empty `latitude` or `longitude` renders as invalid JavaScript (`"lat": ,`), throwing a `SyntaxError` that aborts the whole map script — so **no pins render at all**. This took the live /cities map down when *CityCamp Gainesville* was added without coordinates.

## Fix
Wrap each city entry in a Liquid guard so events missing either coordinate are skipped:

```liquid
{% raw %}{% if event.latitude and event.longitude and event.latitude != "" and event.longitude != "" %}{% endraw %}
```

A coordinate-less row (which can't be placed on a map anyway) is now left off instead of breaking everything. Valid `0` coordinates still render.

## Note
This is a defensive safety net. The root-cause data fix (adding Gainesville's coordinates in Airtable) is handled separately via the events.json resync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)