### PR TITLE
Fix slug collisions for cities with multiple events

### DIFF
--- a/lib/airtable.rb
+++ b/lib/airtable.rb
@@ -43,6 +43,23 @@ events = events.map do |row|
   row
 end
 
+# Ensure slugs are unique. A city that hosted CityCamp in more than one year
+# derives the same base slug (city + region + country) and would otherwise
+# collide onto a single /events/ page — so every pin for that city links to
+# whichever record generated the page. Append the event year to any shared
+# slug; fall back to a numeric suffix when a year is unavailable or still ties.
+events.group_by { |e| e["slug"] }.each_value do |group|
+  next if group.size == 1
+  seen = Hash.new(0)
+  group.each do |row|
+    year = (Date.parse(row["date"]).year rescue nil)
+    candidate = year ? "#{row["slug"]}-#{year}" : row["slug"]
+    seen[candidate] += 1
+    candidate = "#{candidate}-#{seen[candidate]}" if seen[candidate] > 1
+    row["slug"] = candidate
+  end
+end
+
 # order by `slug`
 events = events.sort_by { |e| e["slug"] }
 


### PR DESCRIPTION
## Problem
Event slugs are generated in `lib/airtable.rb` from **city + region + country only**. A city that hosted CityCamp in more than one year produces the *same* slug, so only one `/events/{slug}` page is generated and every map pin for that city links to it.

Confirmed collisions in the current data:
- `gainesville-fl-united-states` → Gainesville **2025** + **2026** (the reported bug: 2026 pin opens the 2025 page)
- `oakland-ca-united-states` → Oakland ×2
- `san-francisco-ca-united-states` → San Francisco ×2

## Fix
After base slugs are assigned, a disambiguation pass appends the event **year** to any slug shared by more than one event, with a numeric-suffix fallback if a year is missing or still ties. Single-event cities are untouched.

Result (verified against the real data):
```
Gainesville 2026 -> gainesville-fl-united-states-2026
Gainesville 2025 -> gainesville-fl-united-states-2025
Oakland (no date) -> oakland-ca-united-states
Oakland 2025      -> oakland-ca-united-states-2025
SF (no date)      -> san-francisco-ca-united-states
SF 2025           -> san-francisco-ca-united-states-2025
Atlanta (single)  -> atlanta-ga-united-states   (unchanged)
```

## Rollout
This changes the pipeline, not `_data/events.json` directly. After merge, the "Update events.json from Airtable" workflow must run to regenerate the data with the new unique slugs, then that branch is merged to deploy.

## Note
The Oakland and San Francisco pairs may be duplicate Airtable rows rather than distinct events — flagged separately for a data review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)