### PR TITLE
Update events.json from Airtable — NYC region fix (2026-07-23)

### DIFF
--- a/_data/events.json
+++ b/_data/events.json
@@ -469,6 +469,34 @@
     "description": "Monterrey, Mexico"
   },
   {
+    "latitude": 40.746429,
+    "address": [
+      "recr3PrtajDSCdTLs"
+    ],
+    "organizer-url": "https://beta.nyc",
+    "organizer": "BetaNYC",
+    "price": "TBD",
+    "date": "2025-09-06",
+    "addressLocality": "Long Island City",
+    "streetAddress": "2 Ct Square W",
+    "Status": "Done",
+    "email": "citycamp@beta.nyc",
+    "addressRegion": "NY",
+    "addressCountry": "United States",
+    "postalCode": "11101",
+    "country": [
+      "rec45yssRULp5R735"
+    ],
+    "longitude": -73.944069,
+    "city": "New York City",
+    "name": "CityCamp NYC 2025",
+    "venue": "CUNY School of Law",
+    "poc": "BetaNYC",
+    "website": "https://www.citycamp.nyc",
+    "slug": "new-york-city-ny-united-states-2025",
+    "description": "September 06, 2025, New York City, NY, United States"
+  },
+  {
     "latitude": 40.7859227,
     "address": [
       "recr3PrtajDSCdTLs"
@@ -493,33 +521,8 @@
     "venue": "Hunter College",
     "poc": "Duncan Ballantine",
     "website": "www.citycamp.nyc",
-    "slug": "new-york-city-ny-united-states",
+    "slug": "new-york-city-ny-united-states-2026",
     "description": "September 19, 2026, New York City, NY, United States"
-  },
-  {
-    "latitude": 40.746429,
-    "organizer-url": "https://beta.nyc",
-    "organizer": "BetaNYC",
-    "price": "TBD",
-    "date": "2025-09-06",
-    "addressLocality": "Long Island City",
-    "streetAddress": "2 Ct Square W",
-    "Status": "Done",
-    "email": "citycamp@beta.nyc",
-    "addressCountry": "United States",
-    "postalCode": "11101",
-    "country": [
-      "rec45yssRULp5R735"
-    ],
-    "longitude": -73.944069,
-    "city": "New York City",
-    "name": "CityCamp NYC 2025",
-    "venue": "CUNY School of Law",
-    "poc": "BetaNYC",
-    "website": "https://www.citycamp.nyc",
-    "addressRegion": null,
-    "slug": "new-york-city-united-states",
-    "description": "September 06, 2025, New York City, United States"
   },
   {
     "latitude": 37.8044,


### PR DESCRIPTION
Resync after adding the missing 'NY' region to CityCamp NYC 2025. Both NYC records now derive matching base slugs and get year suffixes (new-york-city-ny-united-states-2025 / -2026), consistent with the Gainesville convention. No duplicate slugs remain.