### PR TITLE
Update events.json from Airtable (2026-08-13) — add Oakland + Philly

### DIFF
--- a/_data/events.json
+++ b/_data/events.json
@@ -525,6 +525,32 @@
     "description": "September 19, 2026, New York City, NY, United States"
   },
   {
+    "address": [
+      "recr4iFAkL0rm7JgV"
+    ],
+    "organizer-url": "https://openoakland.org/",
+    "organizer": "OpenOakland",
+    "price": "0",
+    "date": "2026-10-17",
+    "addressLocality": "Oakland",
+    "streetAddress": "1 Frank H. Ogawa Plaza",
+    "Status": "In progress",
+    "email": "rowley.cristy@openoakland.org",
+    "addressRegion": "CA",
+    "addressCountry": "United States",
+    "postalCode": "94612",
+    "country": [
+      "rec45yssRULp5R735"
+    ],
+    "city": "Oakland, CA",
+    "name": "CityCamp Oakland",
+    "venue": "Oakland City Hall",
+    "poc": "Cristy Rowley",
+    "website": "https://citycamp.eventbrite.com/?aff=Citycampcom",
+    "slug": "oakland-ca-ca-united-states",
+    "description": "October 17, 2026, Oakland, CA, CA, United States"
+  },
+  {
     "latitude": 37.8044,
     "address": [
       "recr4iFAkL0rm7JgV"
@@ -600,6 +626,32 @@
     "addressRegion": null,
     "slug": "perm-russia",
     "description": "Perm, Russia"
+  },
+  {
+    "address": [
+      "recWpxAukvOgLTSmL"
+    ],
+    "organizer-url": "phillyethics.org",
+    "organizer": "Philadelphia Ethical Society",
+    "price": "TBD",
+    "date": "2026-11-15",
+    "addressLocality": "Philadelphia",
+    "streetAddress": "1906 Rittenhouse Square",
+    "Status": "In progress",
+    "email": "leader@phillyethics.org",
+    "addressRegion": "PA",
+    "addressCountry": "United States",
+    "postalCode": "19106",
+    "country": [
+      "rec45yssRULp5R735"
+    ],
+    "city": "Philadelphia ",
+    "name": "CityCamp Philly",
+    "venue": "Philadelphia Ethical Society",
+    "poc": "Philip Lindsay",
+    "website": "TBD",
+    "slug": "philadelphia--pa-united-states",
+    "description": "November 15, 2026, Philadelphia , PA, United States"
   },
   {
     "latitude": 33.4484,


### PR DESCRIPTION
Pulls the latest CityCamp event locations from Airtable.

## Changes

- **CityCamp Oakland** — Oct 17, 2026, Oakland City Hall (In progress)
- **CityCamp Philly** — Nov 15, 2026, Philadelphia Ethical Society (In progress)

## ⚠️ Missing coordinates

Neither new record has `latitude`/`longitude` in `_data/events.json`, so the map will skip them (per the hardening added 2026-07-23). To make the pins render, add lat/lng to those two rows in Airtable and re-run the sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)