### PR TITLE
Fix slug: strip region from city, drop stray hyphens

### DIFF
--- a/_data/events.json
+++ b/_data/events.json
@@ -571,6 +571,32 @@
     "description": "September 20, 2025, Oakland, CA, United States"
   },
   {
+    "address": [
+      "recr4iFAkL0rm7JgV"
+    ],
+    "organizer-url": "https://openoakland.org/",
+    "organizer": "OpenOakland",
+    "price": "0",
+    "date": "2026-10-17",
+    "addressLocality": "Oakland",
+    "streetAddress": "1 Frank H. Ogawa Plaza",
+    "Status": "In progress",
+    "email": "rowley.cristy@openoakland.org",
+    "addressRegion": "CA",
+    "addressCountry": "United States",
+    "postalCode": "94612",
+    "country": [
+      "rec45yssRULp5R735"
+    ],
+    "city": "Oakland, CA",
+    "name": "CityCamp Oakland",
+    "venue": "Oakland City Hall",
+    "poc": "Cristy Rowley",
+    "website": "https://citycamp.eventbrite.com/?aff=Citycampcom",
+    "slug": "oakland-ca-united-states-2026",
+    "description": "October 17, 2026, Oakland, CA, United States"
+  },
+  {
     "latitude": 35.4676,
     "address": [
       "recMJ6zwJrmx3V6A5"
@@ -600,6 +626,32 @@
     "addressRegion": null,
     "slug": "perm-russia",
     "description": "Perm, Russia"
+  },
+  {
+    "address": [
+      "recWpxAukvOgLTSmL"
+    ],
+    "organizer-url": "phillyethics.org",
+    "organizer": "Philadelphia Ethical Society",
+    "price": "TBD",
+    "date": "2026-11-15",
+    "addressLocality": "Philadelphia",
+    "streetAddress": "1906 Rittenhouse Square",
+    "Status": "In progress",
+    "email": "leader@phillyethics.org",
+    "addressRegion": "PA",
+    "addressCountry": "United States",
+    "postalCode": "19106",
+    "country": [
+      "rec45yssRULp5R735"
+    ],
+    "city": "Philadelphia ",
+    "name": "CityCamp Philly",
+    "venue": "Philadelphia Ethical Society",
+    "poc": "Philip Lindsay",
+    "website": "TBD",
+    "slug": "philadelphia-pa-united-states",
+    "description": "November 15, 2026, Philadelphia, PA, United States"
   },
   {
     "latitude": 33.4484,
@@ -869,7 +921,7 @@
     "longitude": -77.0369,
     "city": "Washington, D.C.",
     "name": "CityCamp Washington, D.C.",
-    "slug": "washington-dc-dc-united-states",
-    "description": "Washington, D.C., DC, United States"
+    "slug": "washington-dc-united-states",
+    "description": "Washington, DC, United States"
   }
 ]

--- a/_data/events.json
+++ b/_data/events.json
@@ -571,6 +571,7 @@
     "description": "September 20, 2025, Oakland, CA, United States"
   },
   {
+    "latitude": 37.8051197,
     "address": [
       "recr4iFAkL0rm7JgV"
     ],
@@ -588,7 +589,8 @@
     "country": [
       "rec45yssRULp5R735"
     ],
-    "city": "Oakland, CA",
+    "longitude": -122.2718349,
+    "city": "Oakland",
     "name": "CityCamp Oakland",
     "venue": "Oakland City Hall",
     "poc": "Cristy Rowley",
@@ -628,6 +630,7 @@
     "description": "Perm, Russia"
   },
   {
+    "latitude": 39.948654,
     "address": [
       "recWpxAukvOgLTSmL"
     ],
@@ -645,6 +648,7 @@
     "country": [
       "rec45yssRULp5R735"
     ],
+    "longitude": -75.173,
     "city": "Philadelphia ",
     "name": "CityCamp Philly",
     "venue": "Philadelphia Ethical Society",
@@ -806,6 +810,34 @@
     "website": "https://c4sf.me/citycamp",
     "slug": "san-francisco-ca-united-states-2025",
     "description": "September 20, 2025, San Francisco, CA, United States"
+  },
+  {
+    "latitude": 37.776363,
+    "address": [
+      "recr4iFAkL0rm7JgV"
+    ],
+    "organizer-url": "https://www.sfcivictech.org",
+    "organizer": "SF Civic Tech",
+    "price": "Free, suggested $20 donation",
+    "date": "2026-09-19",
+    "addressLocality": "San Francisco",
+    "streetAddress": "550 Laguna St",
+    "Status": "In progress",
+    "email": "hello@sfcivictech.org",
+    "addressRegion": "CA",
+    "addressCountry": "United States",
+    "postalCode": "94102",
+    "country": [
+      "rec45yssRULp5R735"
+    ],
+    "longitude": -122.4261,
+    "city": "San Francisco",
+    "name": "CityCamp SF",
+    "venue": "The Commons",
+    "poc": "SF Civic Tech",
+    "website": "https://c4sf.me/citycamp",
+    "slug": "san-francisco-ca-united-states-2026",
+    "description": "September 19, 2026, San Francisco, CA, United States"
   },
   {
     "latitude": -33.4489,

--- a/lib/airtable.rb
+++ b/lib/airtable.rb
@@ -16,29 +16,50 @@ events = Event.all.map(&:fields)
 # Sort by State then City
 events = events.sort_by { |h| [h["State"], h["City"]] }
 
+# Drop a trailing ", REGION" from a free-text city so the region is not
+# duplicated in slug or description when addressRegion already carries it.
+# Compares alphanumerics only so "D.C." matches region "DC".
+def normalize_city(city, region)
+  city = city.to_s.strip
+  region = region.to_s.strip
+  return city if region.empty?
+  region_norm = region.gsub(/\W/, '').downcase
+  m = city.match(/\A(.*?)[,\s]+([^,]+?)\s*\z/)
+  return city unless m
+  m[2].gsub(/\W/, '').downcase == region_norm ? m[1].strip : city
+end
+
 # for each Event, set custom `slug`` & `description` attribute
 events = events.map do |row|
   row["addressRegion"] = row["addressRegion"]&.first # pluck the first value for the CityCamp side.
   row["addressCountry"] = row["addressCountry"]&.first
 
+  city = normalize_city(row["city"], row["addressRegion"])
+
   parts = [
-    row["city"].gsub(" ", "-"),
+    city,
     row["addressRegion"],
     row["addressCountry"]
   ]
   .compact # remove nil
+  .map { |p| p.to_s.strip }
   .reject(&:empty?)
 
   description_parts = [
     row["date"] ? Date.parse(row["date"]).strftime("%B %d, %Y") : "",
-    row["city"],
+    city,
     row["addressRegion"],
     row["addressCountry"]
   ]
   .compact # remove nil
+  .map { |p| p.to_s.strip }
   .reject(&:empty?)
 
-  row["slug"] = parts.map { |part| part.to_s.gsub(".", "").gsub(",", "").gsub(" ", "-").downcase }.join('-')
+  row["slug"] = parts
+    .map { |part| part.to_s.gsub(".", "").gsub(",", "").gsub(" ", "-").downcase }
+    .join('-')
+    .gsub(/-+/, '-')
+    .gsub(/\A-|-\z/, '')
   row["description"] = description_parts.join(', ')
   row
 end


### PR DESCRIPTION
The slug generator concatenated `city + region + country`. When the free-text `city` field already ended with the region (\"Oakland, CA\", \"Washington, D.C.\") or carried trailing whitespace (\"Philadelphia \"), it produced doubled or malformed slugs:

| city | region | old slug | new slug |
|---|---|---|---|
| Oakland, CA | CA | `oakland-ca-ca-united-states` | `oakland-ca-united-states-2026` * |
| Philadelphia (trailing space) | PA | `philadelphia--pa-united-states` | `philadelphia-pa-united-states` |
| Washington, D.C. | DC | `washington-dc-dc-united-states` | `washington-dc-united-states` |

\* Oakland auto-gets `-2026` because prior Oakland records already own the base slug and the 2025 disambiguated slug.

## What changed

- `lib/airtable.rb`: new `normalize_city(city, region)` strips a trailing region suffix (matches on alphanumerics only, so \"D.C.\" matches \"DC\"). Each part is stripped and repeated hyphens are collapsed. Multi-word (\"New York City\") and hyphenated (\"Winston-Salem\") cities are preserved.
- `_data/events.json`: regenerated so the fix ships in one deploy. Includes today's Oakland + Philly additions from `update-events-2026-08-13` (supersedes #251, which can be closed).

## Compatibility

One existing URL changes: `/events/washington-dc-dc-united-states/` → `/events/washington-dc-united-states/`. The old URL had the doubled-DC bug from day one; no evidence it is linked externally.

Verified locally against: Oakland/CA, Philadelphia trailing-space, Washington D.C., New York City/NY, Walla Walla/WA, Perm/(no region), San Francisco/CA, Rio Rancho/NM, Winston-Salem/NC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)