### PR TITLE
Fix URL scheme: bare domains rendered as relative links

### DIFF
--- a/_data/events.json
+++ b/_data/events.json
@@ -501,7 +501,7 @@
     "address": [
       "recr3PrtajDSCdTLs"
     ],
-    "organizer-url": "www.beta.nyc",
+    "organizer-url": "https://www.beta.nyc",
     "organizer": "BetaNYC",
     "price": "$30-$50",
     "date": "2026-09-19",
@@ -520,7 +520,7 @@
     "name": "CityCamp NYC 2026",
     "venue": "Hunter College",
     "poc": "Duncan Ballantine",
-    "website": "www.citycamp.nyc",
+    "website": "https://www.citycamp.nyc",
     "slug": "new-york-city-ny-united-states-2026",
     "description": "September 19, 2026, New York City, NY, United States"
   },
@@ -634,7 +634,7 @@
     "address": [
       "recWpxAukvOgLTSmL"
     ],
-    "organizer-url": "phillyethics.org",
+    "organizer-url": "https://phillyethics.org",
     "organizer": "Philadelphia Ethical Society",
     "price": "TBD",
     "date": "2026-11-15",

--- a/lib/airtable.rb
+++ b/lib/airtable.rb
@@ -29,10 +29,24 @@ def normalize_city(city, region)
   m[2].gsub(/\W/, '').downcase == region_norm ? m[1].strip : city
 end
 
+# Prepend https:// when a URL field has no scheme, so "www.example.org" or a
+# bare domain does not render as a relative link. Preserves mailto: and empty
+# or placeholder values (TBD).
+def normalize_url(url)
+  url = url.to_s.strip
+  return url if url.empty?
+  return url if url =~ /\A(https?|mailto):/i
+  return url if url.upcase == 'TBD'
+  "https://#{url}"
+end
+
 # for each Event, set custom `slug`` & `description` attribute
 events = events.map do |row|
   row["addressRegion"] = row["addressRegion"]&.first # pluck the first value for the CityCamp side.
   row["addressCountry"] = row["addressCountry"]&.first
+
+  row["website"] = normalize_url(row["website"]) if row.key?("website")
+  row["organizer-url"] = normalize_url(row["organizer-url"]) if row.key?("organizer-url")
 
   city = normalize_city(row["city"], row["addressRegion"])
 


### PR DESCRIPTION
The CityCamp NYC 2026 Register and Website buttons were broken because the Airtable row had `www.citycamp.nyc` and `www.beta.nyc` without a scheme. Rendered in `<a href>`, browsers treat those as relative paths — the button links resolved to `citycamp.com/cities/new-york-city-ny-united-states-2026/www.citycamp.nyc`.

## What changed

- `lib/airtable.rb`: new `normalize_url` prepends `https://` when a URL field has no scheme. Preserves `mailto:`, empty strings, and the `TBD` placeholder.
- `_data/events.json`: regenerated. Three URLs now have `https://` prefixed:
  - CityCamp NYC 2026: `website`, `organizer-url`
  - CityCamp Philly: `organizer-url`

## Airtable follow-up

Duncan should also fix the source rows in Airtable so future syncs don't drift back — Marvin isn't authorized to write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)